### PR TITLE
Improved fill progress saving & restoring

### DIFF
--- a/src/main/java/com/wimbli/WorldBorder/Config.java
+++ b/src/main/java/com/wimbli/WorldBorder/Config.java
@@ -491,10 +491,10 @@ public class Config
 			logConfig("Border-checking timed task stopped.");
 	}
 
-	public static void StopFillTask()
+	public static void StopFillTask(boolean SaveFill)
 	{
 		if (fillTask != null && fillTask.valid())
-			fillTask.cancel();
+			fillTask.cancel(SaveFill);
 	}
 
 	public static void StoreFillTask()
@@ -686,16 +686,15 @@ public class Config
 		if (storedFillTask != null)
 		{
 			String worldName = storedFillTask.getString("world");
-			int fillDistance = storedFillTask.getInt("fillDistance", 176);
-			int chunksPerRun = storedFillTask.getInt("chunksPerRun", 5);
-			int tickFrequency = storedFillTask.getInt("tickFrequency", 20);
+			int fillDistance = storedFillTask.getInt("fillDistance", 208);
+			int chunksPerRun = storedFillTask.getInt("chunksPerRun", 1);
+			int tickFrequency = storedFillTask.getInt("tickFrequency", 1);
 			int fillX = storedFillTask.getInt("x", 0);
 			int fillZ = storedFillTask.getInt("z", 0);
 			int fillLength = storedFillTask.getInt("length", 0);
 			int fillTotal = storedFillTask.getInt("total", 0);
 			boolean forceLoad = storedFillTask.getBoolean("forceLoad", false);
 			RestoreFillTask(worldName, fillDistance, chunksPerRun, tickFrequency, fillX, fillZ, fillLength, fillTotal, forceLoad);
-			save(false);
 		}
 
 		if (logIt)

--- a/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldBorder.java
@@ -48,7 +48,7 @@ public class WorldBorder extends JavaPlugin
 		DynMapFeatures.removeAllBorders();
 		Config.StopBorderTimer();
 		Config.StoreFillTask();
-		Config.StopFillTask();
+		Config.StopFillTask(true);
 	}
 
 	// for other plugins to hook into

--- a/src/main/java/com/wimbli/WorldBorder/WorldFillTask.java
+++ b/src/main/java/com/wimbli/WorldBorder/WorldFillTask.java
@@ -120,7 +120,7 @@ public class WorldFillTask implements Runnable
 				sendMessage("You must specify a world!");
 			else
 				sendMessage("World \"" + worldName + "\" not found!");
-			this.stop();
+			this.stop(true);
 			return;
 		}
 
@@ -128,7 +128,7 @@ public class WorldFillTask implements Runnable
 		if (this.border == null)
 		{
 			sendMessage("No border found for world \"" + worldName + "\"!");
-			this.stop();
+			this.stop(false);
 			return;
 		}
 
@@ -136,7 +136,7 @@ public class WorldFillTask implements Runnable
 		worldData = WorldFileData.create(world, notifyPlayer);
 		if (worldData == null)
 		{
-			this.stop();
+			this.stop(false);
 			return;
 		}
 		
@@ -169,7 +169,7 @@ public class WorldFillTask implements Runnable
 
 	public void setTaskID(int ID)
 	{	
-		if (ID == -1) this.stop();
+		if (ID == -1) this.stop(false);
 		this.taskID = ID;
 	}
 
@@ -358,7 +358,9 @@ public class WorldFillTask implements Runnable
 				lastLegX = x;
 				lastLegZ = z;
 				lastLegTotal = reportTotal + reportNum;
-			} else {
+			}
+			else
+			{
 				refX = lastLegX;
 				refZ = lastLegZ;
 				refTotal = lastLegTotal;
@@ -424,18 +426,22 @@ public class WorldFillTask implements Runnable
 		world.save();
 		Bukkit.getServer().getPluginManager().callEvent(new WorldBorderFillFinishedEvent(world, reportTotal));
 		sendMessage("task successfully completed for world \"" + refWorld() + "\"!");
-		this.stop();
+		this.stop(false);
 	}
 
 	// for cancelling prematurely
-	public void cancel()
+	public void cancel(boolean SaveFill)
 	{
-		this.stop();
+		this.stop(SaveFill);
 	}
 
 	// we're done, whether finished or cancelled
-	private void stop()
+	private void stop(boolean SaveFill)
 	{
+		//If being called by onDisable(), don't delete fill progress
+		if (!SaveFill)
+			Config.UnStoreFillTask();
+
 		if (server == null)
 			return;
 
@@ -484,8 +490,7 @@ public class WorldFillTask implements Runnable
 			Config.StoreFillTask();
 			reportProgress();
 		}
-		else
-			Config.UnStoreFillTask();
+
 	}
 	public boolean isPaused()
 	{
@@ -526,6 +531,8 @@ public class WorldFillTask implements Runnable
 			lastAutosave = lastReport;
 			sendMessage("Saving the world to disk, just to be on the safe side.");
 			world.save();
+			//In case of hard-crashes
+			Config.StoreFillTask();
 		}
 	}
 
@@ -561,6 +568,11 @@ public class WorldFillTask implements Runnable
 		this.length = length;
 		this.reportTotal = totalDone;
 		this.continueNotice = true;
+		//Prevents saving zeroes on first StoreFillTask after restoring
+		this.refX = x;
+		this.refZ = z;
+		this.refLength = length;
+		this.refTotal = totalDone;
 	}
 	public int refX()
 	{

--- a/src/main/java/com/wimbli/WorldBorder/cmd/CmdFill.java
+++ b/src/main/java/com/wimbli/WorldBorder/cmd/CmdFill.java
@@ -41,7 +41,7 @@ public class CmdFill extends WBCmd
 					return;
 				sender.sendMessage(C_HEAD + "Cancelling the world map generation task.");
 				fillDefaults();
-				Config.StopFillTask();
+				Config.StopFillTask(false);
 				return;
 			}
 			else if (check.equals("pause"))


### PR DESCRIPTION
* Added fill progress save to autosave, to avoid lost progress on hard-crashes

* Prevented fill progress from being deleted except when properly finished or terminated.

* In case fill progress is saved, but world is not loaded yet when config is loaded, running /wb reload should now resume filling if the world is loaded then.

* Updated restoreprogress default values to match the current defaults.

Thanks too Northbadge for this.

@FaberoM 
Hope this can be merged without losing anything cause i have no idea how github works lmao
I've tested it and it works as expected.